### PR TITLE
"Crash" fix for getTitle

### DIFF
--- a/audioview/src/main/java/com/keenfin/audioview/AudioView.java
+++ b/audioview/src/main/java/com/keenfin/audioview/AudioView.java
@@ -207,7 +207,9 @@ public class AudioView extends FrameLayout implements View.OnClickListener {
             @Override
             public void onPrepared(MediaPlayer mp) {
                 mIsPrepared = true;
-                mTitle.setText(getTrackTitle());
+                if (mShowTitle) {
+                    mTitle.setText(getTrackTitle());
+                }
                 if (mTotalTime != null)
                     mTotalTime.setText(formatTime(mMediaPlayer.getDuration()));
                 mProgress.setProgress(0);

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 05 16:33:33 MSK 2018
+#Mon Oct 22 09:24:52 MSK 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
I'm getting the crash. So, I've decided to take the `showTitle` into account and ignore the title in case I've specified I don't need it. Of course, it also removed the crash (by ignoring the title).

This happens when I play audio from URI. 

```Fatal Exception: java.lang.IllegalArgumentException
       at android.media.MediaMetadataRetriever.setDataSource(MediaMetadataRetriever.java:71)
       at com.keenfin.audioview.AudioView.getTrackTitle(AudioView.java:392)
       at com.keenfin.audioview.AudioView$5.onPrepared(AudioView.java:210)
       at android.media.MediaPlayer$EventHandler.handleMessage(MediaPlayer.java:2872)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:154)
       at android.app.ActivityThread.main(ActivityThread.java:6119)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)```